### PR TITLE
Fix base URL detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ common services.
 
  - Modular PHP utilities organized into classes under `app/`
  - Backward-compatible wrappers remain in `includes/`
- - Configuration file `includes/config.php` defines the base URL and services to monitor
+- Configuration file `includes/config.php` defines services to monitor and can override the base URL if needed
 - AJAX endpoint `api/status.php` returns live service status
 - jQuery driven interface with periodic refresh of service status
 - Basic pages for diagnostics and server information
 
-To run locally place the repository inside your web root (e.g. `/var/www/html/delphi`) and ensure the web server has permission to execute `systemctl` for service checks. Update `base_url` in `includes/config.php` if you deploy the dashboard under a different path.
+To run locally place the repository inside your web root (e.g. `/var/www/html/delphi`) and ensure the web server has permission to execute `systemctl` for service checks. The dashboard will automatically determine the correct base path; only set `base_url` in `includes/config.php` if you need to override this detection.
 
 For improved security set your web server's document root to the `public/`
 directory so that PHP source files in `includes/` remain inaccessible from the
@@ -35,8 +35,9 @@ app/
 
 ### Available Pages
 
-After setting the document root to `public/` the application is accessible at
-`<base_url>`. The following pages are available:
+After setting the document root to `public/`, the application is accessible at
+the detected base path (or the value you specify in `base_url`). The following
+pages are available:
 
 - `/index.php` – Main dashboard with system overview and service status
 - `/pages/system_info.php` – Detailed system information

--- a/includes/config.php
+++ b/includes/config.php
@@ -2,8 +2,9 @@
 // Delphi LAMP Server configuration
 // Adjust monitored services for your Fedora server
 return [
-    // Base URL for links and assets, without trailing slash
-    'base_url' => '/delphi',
+    // Base URL for links and assets, without trailing slash.
+    // Leave empty to automatically detect the correct path
+    'base_url' => '',
 
     'monitored_services' => [
         'httpd',

--- a/includes/header.php
+++ b/includes/header.php
@@ -1,6 +1,16 @@
 <?php
 $config = include __DIR__ . '/config.php';
 $baseUrl = rtrim($config['base_url'] ?? '', '/');
+
+// Auto-detect base path if none provided in config
+if ($baseUrl === '') {
+    $scriptDir = rtrim(dirname($_SERVER['SCRIPT_NAME']), '/');
+    if (substr($scriptDir, -7) === '/public') {
+        $scriptDir = substr($scriptDir, 0, -7);
+    }
+    $baseUrl = $scriptDir ?: '';
+}
+
 if (!defined('BASE_URL')) {
     define('BASE_URL', $baseUrl);
 }


### PR DESCRIPTION
## Summary
- auto-detect BASE_URL in `header.php`
- allow overriding with `base_url` config but default to empty
- update README to explain new behaviour

## Testing
- `php -l` on all PHP files

------
https://chatgpt.com/codex/tasks/task_e_6862b28fa4a083279dc813248aae37e4