### PR TITLE
Improve base URL detection for nested pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ common services.
 
  - Modular PHP utilities organized into classes under `app/`
  - Backward-compatible wrappers remain in `includes/`
- - Configuration file `includes/config.php` defines the base URL and services to monitor
+- Configuration file `includes/config.php` defines services to monitor and can override the base URL if needed
 - AJAX endpoint `api/status.php` returns live service status
 - jQuery driven interface with periodic refresh of service status
 - Basic pages for diagnostics and server information
 
-To run locally place the repository inside your web root (e.g. `/var/www/html/delphi`) and ensure the web server has permission to execute `systemctl` for service checks. Update `base_url` in `includes/config.php` if you deploy the dashboard under a different path.
+To run locally place the repository inside your web root (e.g. `/var/www/html/delphi`) and ensure the web server has permission to execute `systemctl` for service checks. The dashboard will automatically determine the correct base path; only set `base_url` in `includes/config.php` if you need to override this detection. The auto-detection works whether your document root is the repository itself or the `public/` subfolder, and it now correctly resolves links when serving pages from the `pages/` or `api/` directories.
 
 For improved security set your web server's document root to the `public/`
 directory so that PHP source files in `includes/` remain inaccessible from the
@@ -35,8 +35,9 @@ app/
 
 ### Available Pages
 
-After setting the document root to `public/` the application is accessible at
-`<base_url>`. The following pages are available:
+After setting the document root to `public/`, the application is accessible at
+the detected base path (or the value you specify in `base_url`). The following
+pages are available:
 
 - `/index.php` – Main dashboard with system overview and service status
 - `/pages/system_info.php` – Detailed system information

--- a/includes/config.php
+++ b/includes/config.php
@@ -2,8 +2,9 @@
 // Delphi LAMP Server configuration
 // Adjust monitored services for your Fedora server
 return [
-    // Base URL for links and assets, without trailing slash
-    'base_url' => '/delphi',
+    // Base URL for links and assets, without trailing slash.
+    // Leave empty to automatically detect the correct path
+    'base_url' => '',
 
     'monitored_services' => [
         'httpd',

--- a/includes/header.php
+++ b/includes/header.php
@@ -1,6 +1,15 @@
 <?php
 $config = include __DIR__ . '/config.php';
 $baseUrl = rtrim($config['base_url'] ?? '', '/');
+
+// Auto-detect base path if none provided in config
+// Handles cases where the web root is the repository or the public folder
+if ($baseUrl === '') {
+    $scriptDir = rtrim(dirname($_SERVER['SCRIPT_NAME']), '/');
+    // Remove subdirectories like /api or /pages so resources load correctly
+    $baseUrl = preg_replace('#/(?:api|pages)$#', '', $scriptDir);
+}
+
 if (!defined('BASE_URL')) {
     define('BASE_URL', $baseUrl);
 }


### PR DESCRIPTION
## Summary
- refine automatic base path calculation
- document how detection now handles `pages/` and `api/` requests

## Testing
- `php -l` on all PHP files

------
https://chatgpt.com/codex/tasks/task_e_6862b28fa4a083279dc813248aae37e4